### PR TITLE
clean up for the proper versioning sake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
-# Script to run Big Catalog CLI
+# Script to run Big Catalog CLI (v4.6.0)
 
 ### Follow the steps below to get started using Big Catalog CLI.
 
-1. Download image from docker repository `docker pull vastdataorg/bc_cli`
-2. Download big-catalog from this repository.
-3. Move `big-catalog` into the `bin/` directory.
-4. Make `big-catalog` executable: `chmod +x big-catalog`
-5. Execute the script.
+1. Select latest release (tag) that is less than or equal to a version of the cluster you plan to use CLI with.
+2. Download image from docker repository `docker pull vastdataorg/vast-db-cli:4.6.0`
+3. Download `big-catalog` from this repository.
+4. Move `big-catalog` into the `/bin/` directory.
+5. Make `big-catalog` executable: `chmod +x /bin/big-catalog`
+6. Execute the script.
 
 The BC CLI is now installed.
 

--- a/big-catalog
+++ b/big-catalog
@@ -1,32 +1,28 @@
 #!/usr/bin/bash
 
-IMAGE_IDS=($(sudo docker images --filter label=role=big-catalog-cli -q))
-if [[ ${#IMAGE_IDS[@]} > 1 ]]; then
-  unset IMAGE_IDS[0]
-  docker rmi -f ${IMAGE_IDS[@]}
-fi
-#echo "Getting big catalog container id"
-IMAGE_ID=($(sudo docker images --filter label=role=big-catalog-cli -q))
+role="big-catalog-cli"
+IMAGE_ID=$(sudo docker images --filter "label=role=$role" --format "{{.ID}} {{.Tag}} {{.CreatedAt}}" |
+           sort -k 3 -r | head -n 1 | awk '{print $1}')
 
-#echo "Running docker image"
-docker run --rm -ti -v ~/.big_catalog:/bc/.big_catalog -v /tmp:/bc_files "$IMAGE_ID" $@
+docker run --rm -ti -v ~/.big_catalog:/bc/.big_catalog -v /tmp:/bc_files "$IMAGE_ID" "$@"
 flag=0
-for i in $@; do
-  if [[ $i == "-f" ]]; then
-    flag=1
-  elif [[ $flag -eq 1 ]]; then
-    path_to=$i
-    break
-  fi
+for i in "$@"; do
+    if [[ $i == "-f" ]]; then
+        flag=1
+    elif [[ $flag -eq 1 ]]; then
+        path_to=$i
+        break
+    fi
 done
+
 if [[ $flag -eq 1 ]]; then
-#  echo "Moving created files to provided dir"
-  root="${path_to::1}"
-  if [[ $root != "/" ]]; then
-    tmp_path="/tmp/$path_to*"
-    path_to="$(pwd)/$path_to"
-  else
-    tmp_path="/tmp$path_to*"
-  fi
-  cp $tmp_path "${path_to%/*}/"
+    root="${path_to::1}"
+    if [[ $root != "/" ]]; then
+        tmp_path="/tmp/$path_to*"
+        path_to="$(pwd)/$path_to"
+    else
+        tmp_path="/tmp$path_to*"
+    fi
+
+    cp "$tmp_path" "${path_to%/*}/"
 fi

--- a/big-catalog
+++ b/big-catalog
@@ -4,6 +4,24 @@ role="big-catalog-cli"
 IMAGE_ID=$(sudo docker images --filter "label=role=$role" --format "{{.ID}} {{.Tag}} {{.CreatedAt}}" |
            sort -k 3 -r | head -n 1 | awk '{print $1}')
 
+if [ -z "$IMAGE_ID" ]; then
+    echo "There is no suitable image. Please, see README at https://github.com/vast-data/vast-db-cli."
+    exit 1
+fi
+
+if [[ "$1" == "--image" ]]; then
+    sudo docker images --format "{{.ID}} {{.Repository}} {{.Tag}} {{.CreatedAt}}" |
+        grep "$IMAGE_ID" |
+        awk '{print "Image ID:", $1; print "Image Name:", $2;
+              print "Image Tag:", $3;  print "Created At:", $4, $5, $6, $7}'
+    exit 0
+fi
+
+if [[ "$1" == "--version" ]]; then
+    sudo docker images --format "{{.ID}} {{.Tag}}" | grep "$IMAGE_ID" |  awk '{print $2}'
+    exit 0
+fi
+
 docker run --rm -ti -v ~/.big_catalog:/bc/.big_catalog -v /tmp:/bc_files "$IMAGE_ID" "$@"
 flag=0
 for i in "$@"; do


### PR DESCRIPTION
- edit README.md to be more clear
- fix big-catalog script to work better when there are multiple images, add quotes where needed, fix indentation
- add `--version` and `--image` options to the script for convenience