### PR TITLE
Fix instructions and run without sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@
 1. Select latest release (tag) that is less than or equal to a version of the cluster you plan to use CLI with.
 2. Download image from docker repository `docker pull vastdataorg/vast-db-cli:4.7.0-sp3`
 3. Download `vast-db-cli` from this repository.
-4. Move `vast-db-cli` into the `/bin/` directory.
-5. Make `vast-db-cli` executable: `chmod +x /bin/vast-db-cli`
-6. Execute the script.
+4. Make `vast-db-cli` executable: `chmod +x vast-db-cli`
+5. Configure it: `./vast-db-cli configure`
 
 The Vast DB CLI is now installed.
 
@@ -15,5 +14,5 @@ The Vast DB CLI is now installed.
 For information about how to use the Vast DB CLI, run the following command:
 
 ```shell
-$ vast-db-cli --help
+$ ./vast-db-cli --help
 ```

--- a/vast-db-cli
+++ b/vast-db-cli
@@ -1,7 +1,7 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 role="vast-db-cli"
-IMAGE_ID=$(sudo docker images --filter "label=role=$role" --format "{{.ID}} {{.Tag}} {{.CreatedAt}}" |
+IMAGE_ID=$(docker images --filter "label=role=$role" --format "{{.ID}} {{.Tag}} {{.CreatedAt}}" |
            sort -k 3 -r | head -n 1 | awk '{print $1}')
 
 if [ -z "$IMAGE_ID" ]; then
@@ -10,7 +10,7 @@ if [ -z "$IMAGE_ID" ]; then
 fi
 
 if [[ "$1" == "--image" ]]; then
-    sudo docker images --format "{{.ID}} {{.Repository}} {{.Tag}} {{.CreatedAt}}" |
+    docker images --format "{{.ID}} {{.Repository}} {{.Tag}} {{.CreatedAt}}" |
         grep "$IMAGE_ID" |
         awk '{print "Image ID:", $1; print "Image Name:", $2;
               print "Image Tag:", $3;  print "Created At:", $4, $5, $6, $7}'
@@ -18,7 +18,7 @@ if [[ "$1" == "--image" ]]; then
 fi
 
 if [[ "$1" == "--version" ]]; then
-    sudo docker images --format "{{.ID}} {{.Tag}}" | grep "$IMAGE_ID" |  awk '{print $2}'
+    docker images --format "{{.ID}} {{.Tag}}" | grep "$IMAGE_ID" |  awk '{print $2}'
     exit 0
 fi
 


### PR DESCRIPTION
This improves the out-of-the-box experience when using this tool.

I don't know what `bin/` directory the instructions refer to, but that's not a common directory in most home directories (Ubutnu, macOS, etc). If the user is savvy enough to have a `bin/` directory and have it on their path they know how to use it.

On macOS bash is in `/bin/bash` and that works on Linux too so use that instead.

Don't use `sudo` inside the script as being suddenly prompted for your password is decidedly unexpected. The user needed to have docker access to pull the image (per the `README.md`) and if not this is probably not the place to hold their hand for it.